### PR TITLE
Bump julia-actions/cache to v3, remove cache-save workaround

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,9 +37,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - name: Load Julia packages from cache
-        id: julia-cache
-        uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - uses: hexaeder/julia-buildpkg@main
       - uses: julia-actions/julia-runtest@v1
         with:
@@ -50,14 +48,6 @@ jobs:
           files: lcov.info
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        if: cancelled() || failure()
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}
 
   docs:
     name: Documentation
@@ -71,9 +61,7 @@ jobs:
       - uses: julia-actions/setup-julia@v2
         with:
           version: 'pre'
-      - name: Load Julia packages from cache
-        id: julia-cache
-        uses: julia-actions/cache@v2
+      - uses: julia-actions/cache@v3
       - name: Configure doc environment
         shell: julia --project=docs --color=yes {0}
         run: |
@@ -95,11 +83,3 @@ jobs:
           using OpPoDyn
           DocMeta.setdocmeta!(OpPoDyn, :DocTestSetup, :(using OpPoDyn); recursive=true)
           doctest(OpPoDyn)
-      - name: Save Julia depot cache on cancel or failure
-        id: julia-cache-save
-        if: cancelled() || failure()
-        uses: actions/cache/save@v4
-        with:
-          path: |
-            ${{ steps.julia-cache.outputs.cache-paths }}
-          key: ${{ steps.julia-cache.outputs.cache-key }}


### PR DESCRIPTION
## Summary

- Bumps \`julia-actions/cache\` to v3 where needed
- Removes the manual \`actions/cache/save\` fallback steps that were needed in v2 to save the cache on failure/cancellation — v3 handles this natively via a post-step (\`save-always: true\` by default)
- Drops the now-orphaned \`id: julia-cache\` and step name from the cache steps

See the [v3 release notes](https://github.com/julia-actions/cache/pull/169) for details.

🤖 Generated with [Claude Code](https://claude.com/claude-code)